### PR TITLE
IMEI Number wrapping

### DIFF
--- a/lib/device_api/android/adb.rb
+++ b/lib/device_api/android/adb.rb
@@ -59,11 +59,7 @@ module DeviceAPI
       end
 
       def self.getdumpsys(serial)
-        result = execute("adb -s #{serial} shell dumpsys input")
-
-        raise ADBCommandError.new(result.stderr) if result.exit != 0
-
-        lines = result.stdout.split("\n").map { |line| line.strip }
+        lines = dumpsys(serial, 'input')
 
         props = {}
         lines.each do |l|
@@ -73,6 +69,25 @@ module DeviceAPI
         end
         props
       end
+
+      def self.getphoneinfo(serial)
+        lines = dumpsys(serial, 'iphonesubinfo')
+
+        props = {}
+        lines.each do |l|
+          if /(.*) =\s+(.*)/.match(l)
+            props[Regexp.last_match[1]] = Regexp.last_match[2]
+          end
+        end
+        props
+      end
+
+      def self.dumpsys(serial, command)
+        result = execute("adb -s #{serial} shell dumpsys iphonesubinfo #{command}")
+        raise ADBCommandError.new(result.stderr) if result.exit != 0
+        result.stdout.split("\n").map { |line| line.strip }
+      end
+
 
       def self.install_apk(options = {})
         apk = options[:apk]

--- a/lib/device_api/android/device.rb
+++ b/lib/device_api/android/device.rb
@@ -82,6 +82,10 @@ module DeviceAPI
         ADB.screencap(serial, args)
       end
 
+      def imei
+        get_phoneinfo['Device ID']
+      end
+
       private
 
       def get_app_props(key)
@@ -101,6 +105,10 @@ module DeviceAPI
       def get_dumpsys(key)
         @props = ADB.getdumpsys(serial)
         @props[key]
+      end
+
+      def get_phoneinfo
+        ADB.getphoneinfo(serial)
       end
 
       def install_apk(apk)


### PR DESCRIPTION
Wrapped 'adb shell dumpsys iphonesubinfo' so that we can get the imei number for a phone. 

Can be used like this:

DeviceAPI::Android.devices.first.imei
