### PR TITLE
Fixes crash when device is unauthorized

### DIFF
--- a/lib/device_api/android.rb
+++ b/lib/device_api/android.rb
@@ -14,7 +14,7 @@ module DeviceAPI
     # Returns array of connected android devices
     def self.devices
       ADB.devices.map do |d|
-        if d.keys.first && !d.keys.first.include?('?')
+        if d.keys.first && !d.keys.first.include?('?') && !d.values.first.include?('unauthorized')
           DeviceAPI::Android::Device.create( self.get_device_type(d.keys.first), { serial: d.keys.first, state: d.values.first } )
         end
       end

--- a/lib/device_api/android.rb
+++ b/lib/device_api/android.rb
@@ -13,11 +13,12 @@ module DeviceAPI
   module Android
     # Returns array of connected android devices
     def self.devices
-      ADB.devices.map do |d|
+      list = ADB.devices.map do |d|
         if d.keys.first && !d.keys.first.include?('?') && !d.values.first.include?('unauthorized')
           DeviceAPI::Android::Device.create( self.get_device_type(d.keys.first), { serial: d.keys.first, state: d.values.first } )
         end
       end
+      list.compact
     end
 
     # Retrieve an Device object by serial id


### PR DESCRIPTION
Any adb event on device with 'Unauthorized' status causes an exception. In order to avoid this device should not be added in devices array.
 
Devices having status as 'Unauthorized' or '??????' should not be returned. 

