### PR TITLE
Utf8 parsing

### DIFF
--- a/lib/device_api/android/adb.rb
+++ b/lib/device_api/android/adb.rb
@@ -42,7 +42,7 @@ module DeviceAPI
 
         raise ADBCommandError.new(result.stderr) if result.exit != 0
 
-        lines = result.stdout.encode('UTF-8', invalid: replace).split("\n")
+        lines = result.stdout.encode('UTF-8', invalid: :replace).split("\n")
 
         process_dumpsys('\[(.*)\]:\s+\[(.*)\]', lines)
       end

--- a/lib/device_api/android/adb.rb
+++ b/lib/device_api/android/adb.rb
@@ -42,7 +42,7 @@ module DeviceAPI
 
         raise ADBCommandError.new(result.stderr) if result.exit != 0
 
-        lines = result.stdout.split("\n")
+        lines = result.stdout.encode('UTF-8', invalid: replace).split("\n")
 
         process_dumpsys('\[(.*)\]:\s+\[(.*)\]', lines)
       end


### PR DESCRIPTION
Fixes the issue of invalid characters being passed back from ADB when querying certain devices (i.e. Kindle Fire HD 8)