### PR TITLE
Added Samsung specific device to kill the multi window bubble (fixes …

### DIFF
--- a/lib/device_api/android.rb
+++ b/lib/device_api/android.rb
@@ -10,6 +10,7 @@ require 'device_api/android/plugins/disk'
 
 # Load additional device types
 require 'device_api/android/device/kindle'
+require 'device_api/android/device/samsung'
 
 module DeviceAPI
   module Android
@@ -38,6 +39,8 @@ module DeviceAPI
       case Device.new(serial: options.keys.first).manufacturer.downcase
         when 'amazon'
           type = :kindle
+        when 'samsung'
+          type = :samsung
         else
           type = :default
       end

--- a/lib/device_api/android/adb.rb
+++ b/lib/device_api/android/adb.rb
@@ -263,11 +263,39 @@ module DeviceAPI
       # @param serial serial number of device 
       # @param command -option activity 
       # @example
-      # DeviceAPI::ADB.am(serial, "-a android.intent.action.MAIN -n com.android.settings/.wifi.WifiSettings")
+      # DeviceAPI::ADB.am(serial, "start -a android.intent.action.MAIN -n com.android.settings/.wifi.WifiSettings")
       def self.am(serial, command)
-        result = execute("adb -s #{serial} shell am start #{command}")
+        result = execute("adb -s #{serial} shell am #{command}")
         raise ADBCommandError.new(result.stderr) if result.exit != 0
         return result.stdout
+      end
+
+      # Package manager commands
+      # @param serial serial of device
+      # @param command command to issue to the package manager
+      # @example DeviceAPI::ADB.pm(serial, 'list packages')
+      def self.pm(serial, command)
+        result = execute("adb -s #{serial} shell pm #{command}")
+        raise ADBCommandError.new(result.stderr) if result.exit != 0
+        return result.stdout
+      end
+
+      # Blocks a package, used on Android versions less than KitKat
+      # Returns boolean
+      # @param serial serial of device
+      # @param package to block
+      def self.block_package(serial, package)
+        result = pm(serial, "block #{package}")
+        result.include?('true')
+      end
+
+      # Blocks a package on KitKat and above
+      # Returns boolean
+      # @param serial serial of device
+      # @param package to hide
+      def self.hide_package(serial, package)
+        result = pm(serial, "hide #{package}")
+        result.include?('true')
       end
     end
 

--- a/lib/device_api/android/device.rb
+++ b/lib/device_api/android/device.rb
@@ -86,6 +86,14 @@ module DeviceAPI
         !get_battery_info.select { |keys| keys.include?('powered')}.select { |_,v| v == 'true' }.empty?
       end
 
+      def block_package(package)
+        if version < "5.0.0"
+          ADB.block_package(serial, package)
+        else
+          ADB.hide_package(serial, package)
+        end
+      end
+
       # Return the device orientation
       # @return (String) current device orientation
       def orientation
@@ -139,6 +147,11 @@ module DeviceAPI
         result = get_app_props('package')['name']
         fail StandardError, 'Package name not found', caller if result.nil?
         result
+      end
+
+      def list_installed_packages
+        packages = ADB.pm(serial, 'list packages')
+        packages.split("\r\n")
       end
 
       # Return the app version number for a specified apk
@@ -220,8 +233,8 @@ module DeviceAPI
       # @param [String] command to start the intent
       # Return the stdout of executed intent
       # @return [String] stdout
-      def start_intent(command)
-        ADB.am(serial,command)
+      def intent(command)
+        ADB.am(serial, command)
       end
 
       #Reboots the device

--- a/lib/device_api/android/device/samsung.rb
+++ b/lib/device_api/android/device/samsung.rb
@@ -1,0 +1,18 @@
+module DeviceAPI
+  module Android
+    # Samsung specific device class
+    class Samsung < Device
+      def initialize(options = {})
+
+        super
+        packages = list_installed_packages
+        multi_window = 'com.sec.android.app.FlashBarService'
+        if packages.include?("package:#{multi_window}")
+          # Stop the multi window function from running and block it
+          intent("force-stop #{multi_window}")
+          block_package("#{multi_window}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
…issue #65)

Added 'pm', 'block_package'  and 'hide_package' commands to ADB
Added 'block_package' command to Device - will redirect to the correct method based on Android version
Renamed 'start_intent' to 'intent' due to the fact that 'am' can do more than just start