### PR TITLE
Added checks for AAPT in methods that use it

### DIFF
--- a/device_api-android.gemspec
+++ b/device_api-android.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'device_api-android'
-  s.version     = '1.2.9'
+  s.version     = '1.2.10'
   s.date        = Time.now.strftime("%Y-%m-%d")
   s.summary     = 'Android Device Management API'
   s.description = 'Android implementation of DeviceAPI'

--- a/lib/device_api/android/signing.rb
+++ b/lib/device_api/android/signing.rb
@@ -54,6 +54,7 @@ module DeviceAPI
       # @param [String] apk_path full path to apk to check
       # @return returns false if the apk is unsigned, true if it is signed
       def self.is_apk_signed?(apk_path)
+        raise SigningCommandError.new('AAPT not available') unless DeviceAPI::Android::AAPT.aapt_available?
         result = execute("aapt list #{apk_path} | grep '^META-INF\/.*'")
         return false if result.stdout.empty?
         true
@@ -63,6 +64,7 @@ module DeviceAPI
       # @param [String] apk_path full path to the apk
       # @return [Boolean, Exception] returns true if the apk is successfully unsigned, otherwise an exception is raised
       def self.unsign_apk(apk_path)
+        raise SigningCommandError.new('AAPT not available') unless DeviceAPI::Android::AAPT.aapt_available?
         file_list = execute("aapt list #{apk_path} | grep '^META-INF\/.*'")
         result = execute("aapt remove #{apk_path} #{file_list.stdout.split(/\s+/).join(' ')}")
         raise SigningCommandError.new(result.stderr) if result.exit != 0


### PR DESCRIPTION
Previously, calls to these methods wouldn't capture the error correctly if AAPT wasn't available