### PR TITLE
Reboot and wait for device to come up

### DIFF
--- a/device_api-android.gemspec
+++ b/device_api-android.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'device_api-android'
-  s.version     = '1.2.12'
+  s.version     = '1.2.13'
   s.date        = Time.now.strftime("%Y-%m-%d")
   s.summary     = 'Android Device Management API'
   s.description = 'Android implementation of DeviceAPI'

--- a/lib/device_api/android/adb.rb
+++ b/lib/device_api/android/adb.rb
@@ -187,11 +187,13 @@ module DeviceAPI
       end
 
       # Reboots the specified device
+      # Remote devices are rebooted and disconnected from system
       # @param qualifier qualifier of device
       # @return (nil) Nil if successful, otherwise an error is raised
       def self.reboot(qualifier, remote)
         if remote
-          result = execute("adb -s #{qualifier} reboot")
+          result = system("adb -s #{qualifier} reboot &")
+          self.disconnect(qualifier.split(":").first)
         else
           result = execute("adb -s #{qualifier} reboot && adb -s #{qualifier} wait-for-device shell 'while [[ $(getprop dev.bootcomplete | tr -d '\r') != 1 ]    ]; do sleep 1; printf .; done'")
         end

--- a/lib/device_api/android/adb.rb
+++ b/lib/device_api/android/adb.rb
@@ -189,8 +189,12 @@ module DeviceAPI
       # Reboots the specified device
       # @param qualifier qualifier of device
       # @return (nil) Nil if successful, otherwise an error is raised
-      def self.reboot(qualifier)
-        result = execute("adb -s #{qualifier} reboot")
+      def self.reboot(qualifier, remote)
+        if remote
+          result = execute("adb -s #{qualifier} reboot")
+        else
+          result = execute("adb -s #{qualifier} reboot && adb -s #{qualifier} wait-for-device shell 'while [[ $(getprop dev.bootcomplete | tr -d '\r') != 1 ]    ]; do sleep 1; printf .; done'")
+        end
         raise ADBCommandError.new(result.stderr) if result.exit != 0
       end
 

--- a/lib/device_api/android/device.rb
+++ b/lib/device_api/android/device.rb
@@ -281,7 +281,7 @@ module DeviceAPI
 
       #Reboots the device
       def reboot
-        ADB.reboot(qualifier)
+        ADB.reboot(qualifier, is_remote?)
       end
 
       # Returns disk status


### PR DESCRIPTION
1. Reboot and wait for usb connected device to restart
2. Simply reboot remotely connected device because it loses adb connection while reboot. Disconnect device after reboot. 
3. Bumped version

Remote device when rebooted doesn't return back the execution, hence it is required to start it in background. When device is disconnected with adb it returns execution or kill background process.