### PR TITLE
Screenshot for android 7.0

### DIFF
--- a/device_api-android.gemspec
+++ b/device_api-android.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'device_api-android'
-  s.version     = '1.2.15'
+  s.version     = '1.2.16'
   s.date        = Time.now.strftime("%Y-%m-%d")
   s.summary     = 'Android Device Management API'
   s.description = 'Android implementation of DeviceAPI'

--- a/lib/device_api/android/adb.rb
+++ b/lib/device_api/android/adb.rb
@@ -236,10 +236,11 @@ module DeviceAPI
       def self.screencap( qualifier, args )
         
         filename = args[:filename] or raise "filename not provided (:filename => '/tmp/myfile.png')"
-        
+ 
         convert_carriage_returns = %q{perl -pe 's/\x0D\x0A/\x0A/g'}
         cmd = "screencap -p | #{convert_carriage_returns} > #{filename}"
         
+        cmd = "screencap -p" if getprop(qualifier)['ro.build.version.release'].to_i > 6
         shell(qualifier, cmd)
       end
       

--- a/lib/device_api/android/adb.rb
+++ b/lib/device_api/android/adb.rb
@@ -236,11 +236,14 @@ module DeviceAPI
       def self.screencap( qualifier, args )
         
         filename = args[:filename] or raise "filename not provided (:filename => '/tmp/myfile.png')"
- 
-        convert_carriage_returns = %q{perl -pe 's/\x0D\x0A/\x0A/g'}
-        cmd = "screencap -p | #{convert_carriage_returns} > #{filename}"
         
-        cmd = "screencap -p" if getprop(qualifier)['ro.build.version.release'].to_i > 6
+        if getprop(qualifier)['ro.build.version.release'].to_i < 7
+          convert_carriage_returns = %q{perl -pe 's/\x0D\x0A/\x0A/g'} 
+          cmd = "screencap -p | #{convert_carriage_returns} > #{filename}"
+        else
+          cmd = "screencap -p > #{filename}"
+        end
+
         shell(qualifier, cmd)
       end
       

--- a/lib/device_api/android/device.rb
+++ b/lib/device_api/android/device.rb
@@ -124,13 +124,13 @@ module DeviceAPI
       # Return the battery level
       # @return (String) device battery level
       def battery_level
-        get_battery_info['level']
+        get_battery_info.level
       end
 
       # Is the device currently being powered?
       # @return (Boolean) true if it is being powered in some way, false if it is unpowered
       def powered?
-        !get_battery_info.select { |keys| keys.include?('powered')}.select { |_,v| v == 'true' }.empty?
+        get_battery_info.powered
       end
 
       def block_package(package)

--- a/lib/device_api/android/plugins/battery.rb
+++ b/lib/device_api/android/plugins/battery.rb
@@ -2,7 +2,7 @@ module DeviceAPI
   module Android
     module Plugin
       class Battery
-        attr_reader :current_temp, :max_temp, :max_current, :voltage, :level, :health, :status
+        attr_reader :current_temp, :max_temp, :max_current, :voltage, :level, :health, :status, :powered
 
         def initialize(options = {})
           qualifier = options[:qualifier]
@@ -14,6 +14,7 @@ module DeviceAPI
           @level          = props["level"]
           @health         = props["health"]
           @status         = props["status"]
+          @powered        = props["USB powered"]
         end
       end
     end


### PR DESCRIPTION
Fix #126 
Battery plugin would return an object instead of an Hash. All previous operations on battery were on hash. Now it is modified to access using '.' 