### PR TITLE
Return nil mac address when netcfg command not found

### DIFF
--- a/device_api-android.gemspec
+++ b/device_api-android.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'device_api-android'
-  s.version     = '1.2.17'
+  s.version     = '1.2.18'
   s.date        = Time.now.strftime("%Y-%m-%d")
   s.summary     = 'Android Device Management API'
   s.description = 'Android implementation of DeviceAPI'

--- a/lib/device_api/android/adb.rb
+++ b/lib/device_api/android/adb.rb
@@ -308,6 +308,8 @@ module DeviceAPI
           raise DeviceAPI::UnauthorizedDevice, result.stderr
         when /^error: device not found/
           raise DeviceAPI::DeviceNotFound, result.stderr
+        when /^\/system\/bin\/sh: netcfg: not found/
+          return result
         else
           raise ADBCommandError.new(result.stderr)
         end if result.exit != 0

--- a/lib/device_api/android/adb.rb
+++ b/lib/device_api/android/adb.rb
@@ -308,6 +308,10 @@ module DeviceAPI
           raise DeviceAPI::UnauthorizedDevice, result.stderr
         when /^error: device not found/
           raise DeviceAPI::DeviceNotFound, result.stderr
+        # ADB.get_network_info on android > 7 behave differently
+        #   On linux exit code is 127
+        #   On MAC exit code is 0
+        # Caught here to give get_network_info consistent response
         when /^\/system\/bin\/sh: netcfg: not found/
           return result
         else


### PR DESCRIPTION
Output of `device.wifi_mac_address` for android > 7
Mac:
`nil` ==> `#<OpenStruct exit=0, stdout="/system/bin/sh: netcfg: not found\n", stderr="">`
Linux
`ADB Command Error` => `#<OpenStruct exit=127, stdout="", stderr="/system/bin/sh: netcfg: not found\n">`

This was causing exception on linux.