### PR TITLE
Wifi mac address

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    device_api-android (1.2.19)
+    device_api-android (1.2.20)
       android-devices
       device_api (~> 1.0.2)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,47 @@
+PATH
+  remote: .
+  specs:
+    device_api-android (1.2.19)
+      android-devices
+      device_api (~> 1.0.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    android-devices (1.0.1)
+    codeclimate-test-reporter (1.0.8)
+      simplecov (<= 0.13)
+    device_api (1.0.2)
+    diff-lcs (1.3)
+    docile (1.1.5)
+    json (2.1.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    simplecov (0.13.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  codeclimate-test-reporter
+  device_api-android!
+  rspec (~> 3)
+  simplecov (~> 0.12)
+
+BUNDLED WITH
+   1.14.6

--- a/device_api-android.gemspec
+++ b/device_api-android.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'device_api-android'
-  s.version     = '1.2.19'
+  s.version     = '1.2.20'
   s.date        = Time.now.strftime("%Y-%m-%d")
   s.summary     = 'Android Device Management API'
   s.description = 'Android implementation of DeviceAPI'

--- a/lib/device_api/android/adb.rb
+++ b/lib/device_api/android/adb.rb
@@ -86,7 +86,7 @@ module DeviceAPI
       def self.get_wifi_mac_address(qualifier)
         lines = shell(qualifier, 'ip address')
         lines = lines.to_s.gsub(/\r\n/, '') if lines
-        match_data = lines.match(/wlan0: .* (\w{2}:\w{2}:\w{2}:\w{2}:\w{2}:\w{2}) \S.* forever/)
+        match_data = lines.match(/wlan0: .+? (\w{2}:\w{2}:\w{2}:\w{2}:\w{2}:\w{2})/)
         match_data[1] if match_data
       end
 

--- a/lib/device_api/android/adb.rb
+++ b/lib/device_api/android/adb.rb
@@ -83,6 +83,13 @@ module DeviceAPI
         end
       end
 
+      def self.get_wifi_mac_address(qualifier)
+        lines = shell(qualifier, 'ip address')
+        lines = lines.to_s.gsub(/\r\n/, '') if lines
+        match_data = lines.match(/wlan0: .* (\w{2}:\w{2}:\w{2}:\w{2}:\w{2}:\w{2}) \S.* forever/)
+        match_data[1] if match_data
+      end
+
       # Processes the results from dumpsys to format them into a hash
       # @param [String] regex_string regex string used to separate the results from the keys
       # @param [Array] data data returned from dumpsys

--- a/lib/device_api/android/device.rb
+++ b/lib/device_api/android/device.rb
@@ -317,14 +317,6 @@ module DeviceAPI
       # Returns the Wifi mac address
       def wifi_mac_address
         return ADB.get_wifi_mac_address(qualifier)
-      #  interface = ADB.get_network_interface(qualifier, 'wlan0')
-      #  if interface.match(/HWaddr (.*)/)
-      #    Regexp.last_match[1].strip
-      #  else
-      #    network = get_network_info
-      #    wifi = network.detect { |a| a[:name] == 'wlan0' }
-      #    wifi[:mac] unless wifi.nil?
-      #  end
       end
 
       def resolution

--- a/lib/device_api/android/device.rb
+++ b/lib/device_api/android/device.rb
@@ -316,14 +316,15 @@ module DeviceAPI
 
       # Returns the Wifi mac address
       def wifi_mac_address
-        interface = ADB.get_network_interface(qualifier, 'wlan0')
-        if interface.match(/HWaddr (.*)/)
-          Regexp.last_match[1].strip
-        else
-          network = get_network_info
-          wifi = network.detect { |a| a[:name] == 'wlan0' }
-          wifi[:mac] unless wifi.nil?
-        end
+        return ADB.get_wifi_mac_address(qualifier)
+      #  interface = ADB.get_network_interface(qualifier, 'wlan0')
+      #  if interface.match(/HWaddr (.*)/)
+      #    Regexp.last_match[1].strip
+      #  else
+      #    network = get_network_info
+      #    wifi = network.detect { |a| a[:name] == 'wlan0' }
+      #    wifi[:mac] unless wifi.nil?
+      #  end
       end
 
       def resolution

--- a/spec/android_spec.rb
+++ b/spec/android_spec.rb
@@ -204,9 +204,17 @@ _______________________________________________________
 
         it 'can return the Wifi mac address' do
           out = <<EOF
-lo       UP                                   127.0.0.1/8   0x00000049 00:00:00:00:00:00
-rmnet_usb0 DOWN                                   0.0.0.0/0   0x00001002 9a:ca:4c:c4:25:5b
-wlan0    UP                                     0.0.0.0/0   0x00001003 fc:c2:de:6a:04:9e
+4: ip6tnl0: <NOARP> mtu 1452 qdisc noop state DOWN 
+    link/tunnel6 :: brd ::
+5: p2p0: <NO-CARRIER,BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state DORMANT qlen 1000
+    link/ether 42:b4:cd:73:8f:8b brd ff:ff:ff:ff:ff:ff
+    inet6 fe80::40b4:cdff:fe73:8f8b/64 scope link 
+       valid_lft forever preferred_lft forever
+6: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether fc:c2:de:6a:04:9e brd ff:ff:ff:ff:ff:ff
+    inet 192.168.101.227/24 brd 192.168.101.255 scope global wlan0
+    inet6 fe80::42b4:cdff:fe73:8f8b/64 scope link 
+       valid_lft forever preferred_lft forever
 EOF
           device = DeviceAPI::Android::Device.new(serial: 'SH34RW905290')
           allow(Open3).to receive(:capture3) { [out, '', STATUS_ZERO] }
@@ -215,14 +223,15 @@ EOF
 
         it 'can return the Wifi mac address on an Android 6.0 and above device' do
           out = <<-EOF
-wlan0     Link encap:Ethernet  HWaddr 00:9A:CD:5E:CC:40
-          inet addr:10.10.1.108  Bcast:10.10.255.255  Mask:255.255.0.0
-          inet6 addr: ff80::29a:cbdf:ff5f:cc40/64 Scope: Link
-          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
-          RX packets:3132210 errors:0 dropped:2310977 overruns:0 frame:0
-          TX packets:87349 errors:0 dropped:0 overruns:0 carrier:0
-          collisions:0 txqueuelen:1000
-          RX bytes:537224812 TX bytes:9711181
+5: p2p0: <NO-CARRIER,BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state DORMANT qlen 1000
+    link/ether 42:b4:cd:73:8f:8b brd ff:ff:ff:ff:ff:ff
+    inet6 fe80::40b4:cdff:fe73:8f8b/64 scope link 
+       valid_lft forever preferred_lft forever
+6: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:9A:CD:5E:CC:40 brd ff:ff:ff:ff:ff:ff
+    inet 192.168.101.227/24 brd 192.168.101.255 scope global wlan0
+    inet6 fe80::42b4:cdff:fe73:8f8b/64 scope link 
+       valid_lft forever preferred_lft forever
           EOF
 
           device = DeviceAPI::Android::Device.new(serial: 'SH34RW905290')
@@ -235,6 +244,7 @@ wlan0     Link encap:Ethernet  HWaddr 00:9A:CD:5E:CC:40
 lo       UP                                   127.0.0.1/8   0x00000049 00:00:00:00:00:00
 rmnet_usb0 DOWN                                   0.0.0.0/0   0x00001002 9a:ca:4c:c4:25:5b
 EOF
+
 
           device = DeviceAPI::Android::Device.new(serial: 'SH34RW905290')
           allow(Open3).to receive(:capture3) { [out, '', STATUS_ZERO] }


### PR DESCRIPTION
`ifconfig` way of wifi_mac_address detection no more works on android 7.0 and above. This is new implementation and works on all. 

refer #92